### PR TITLE
recoginze segrate witness script

### DIFF
--- a/blockchain_parser/script.py
+++ b/blockchain_parser/script.py
@@ -136,7 +136,8 @@ class Script(object):
     def is_unknown(self):
         return not self.is_pubkeyhash() and not self.is_pubkey() \
             and not self.is_p2sh() and not self.is_multisig() \
-            and not self.is_return()
+            and not self.is_return() and not self.is_p2wpkh()\
+            and not self.is_p2wsh()
 
     # add by hzx
     def is_p2wpkh(self):
@@ -144,6 +145,8 @@ class Script(object):
             a = bytes(self.operations[0])
             b = bytes(self.operations[1])
             return len(a)==0 and len(b) == 20
+        
+        return False
 
     # add by hzx
     def is_p2wsh(self):
@@ -151,3 +154,6 @@ class Script(object):
             a = bytes(self.operations[0])
             b = bytes(self.operations[1])
             return len(a)==0 and len(b) == 32
+        
+        return False
+    

--- a/blockchain_parser/script.py
+++ b/blockchain_parser/script.py
@@ -70,8 +70,12 @@ class Script(object):
         """
         if self._operations is None:
             # Some coinbase scripts are garbage, they could not be valid
-            self._operations = list(self.script)
-
+            try:
+                self._operations = list(self.script)
+            except CScriptTruncatedPushDataError:
+                self._operations = "[INVALID]"
+            except CScriptInvalidError:
+                self._operations = "[INVALID]"
         return self._operations
 
     @property
@@ -133,3 +137,17 @@ class Script(object):
         return not self.is_pubkeyhash() and not self.is_pubkey() \
             and not self.is_p2sh() and not self.is_multisig() \
             and not self.is_return()
+
+    # add by hzx
+    def is_p2wpkh(self):
+        if len(self.operations) == 2:
+            a = bytes(self.operations[0])
+            b = bytes(self.operations[1])
+            return len(a)==0 and len(b) == 20
+
+    # add by hzx
+    def is_p2wsh(self):
+        if len(self.operations) == 2:
+            a = bytes(self.operations[0])
+            b = bytes(self.operations[1])
+            return len(a)==0 and len(b) == 32


### PR DESCRIPTION
I add some changes in script.py, I find that some PKscript in output are illegal, the list(self.script) may cause CScriptInvalidError, I add a try catch sentence.

I also add two functions (is_p2wpkh and is_p2wsh) to recoginze segregate PKscripts, according to the two functions, I also alert the is_unknown function.

I have test the functions aforementioned from genesis block to 620000th block, and all of them worked correctly.